### PR TITLE
Add BsonClassDiscriminator annotation

### DIFF
--- a/src/main/kotlin/com/github/jershell/kbson/Annotations.kt
+++ b/src/main/kotlin/com/github/jershell/kbson/Annotations.kt
@@ -2,7 +2,32 @@ package com.github.jershell.kbson
 
 import kotlinx.serialization.InheritableSerialInfo
 
-
+/**
+ * Specifies key for class discriminator value used during polymorphic serialization in [KBson].
+ * Provided key is used only for an annotated class and its subclasses;
+ * to configure global class discriminator, use [Configuration.classDiscriminator]
+ * property.
+ *
+ * This annotation is [inheritable][InheritableSerialInfo], so it should be sufficient to place it on a base class of hierarchy.
+ * It is not possible to define different class discriminators for different parts of class hierarchy.
+ * Pay attention to the fact that class discriminator, same as polymorphic serializer's base class, is
+ * determined statically.
+ *
+ * Example:
+ * ```
+ * @Serializable
+ * @BsonClassDiscriminator("isoCountryCode") // sets discriminator for inheritance hierarchy
+ * sealed interface ImportDocument
+ *
+ * @Serializable
+ * @SerialName("JP") // will result in the element "isoCountryCode": "JP"
+ * class JapaneseImportDocument(
+ *     val id: Long,
+ * ) : ImportDocument
+ * ```
+ *
+ * @see Configuration.classDiscriminator
+ */
 @InheritableSerialInfo
 @Target(AnnotationTarget.CLASS)
 annotation class BsonClassDiscriminator(val discriminator: String)

--- a/src/main/kotlin/com/github/jershell/kbson/Annotations.kt
+++ b/src/main/kotlin/com/github/jershell/kbson/Annotations.kt
@@ -1,0 +1,8 @@
+package com.github.jershell.kbson
+
+import kotlinx.serialization.InheritableSerialInfo
+
+
+@InheritableSerialInfo
+@Target(AnnotationTarget.CLASS)
+annotation class BsonClassDiscriminator(val discriminator: String)

--- a/src/main/kotlin/com/github/jershell/kbson/BsonEncoder.kt
+++ b/src/main/kotlin/com/github/jershell/kbson/BsonEncoder.kt
@@ -1,6 +1,5 @@
 package com.github.jershell.kbson
 
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.descriptors.*

--- a/src/main/kotlin/com/github/jershell/kbson/BsonEncoder.kt
+++ b/src/main/kotlin/com/github/jershell/kbson/BsonEncoder.kt
@@ -1,5 +1,6 @@
 package com.github.jershell.kbson
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.descriptors.*
@@ -47,7 +48,7 @@ open class BsonEncoder(
             }
             is PolymorphicKind -> {
                 writer.writeStartDocument()
-                writer.writeName(configuration.classDiscriminator)
+                writer.writeName(descriptor.classDiscriminator())
                 hasBegin = true
             }
             StructureKind.MAP -> {
@@ -57,6 +58,15 @@ open class BsonEncoder(
             else -> throw SerializationException("Primitives are not supported at top-level")
         }
         return super.beginStructure(descriptor)
+    }
+
+    private fun SerialDescriptor.classDiscriminator(): String {
+        for (annotation in this.annotations) {
+            if (annotation is BsonClassDiscriminator) {
+                return annotation.discriminator
+            }
+        }
+        return configuration.classDiscriminator
     }
 
     override fun endStructure(descriptor: SerialDescriptor) {

--- a/src/test/kotlin/com/github/jershell/kbson/KBsonTest.kt
+++ b/src/test/kotlin/com/github/jershell/kbson/KBsonTest.kt
@@ -28,10 +28,13 @@ import com.github.jershell.kbson.models.WithUUID
 import com.github.jershell.kbson.models.WrapperMapWithAdvancedKey
 import com.github.jershell.kbson.models.WrapperMapWithObjectId
 import com.github.jershell.kbson.models.WrapperSet
+import com.github.jershell.kbson.models.polymorph.AddressNote
 import com.github.jershell.kbson.models.polymorph.FooTimestampedMessage
 import com.github.jershell.kbson.models.polymorph.IntMessage
 import com.github.jershell.kbson.models.polymorph.Message
 import com.github.jershell.kbson.models.polymorph.MessageWrapper
+import com.github.jershell.kbson.models.polymorph.Note
+import com.github.jershell.kbson.models.polymorph.PhoneNote
 import com.github.jershell.kbson.models.polymorph.SMessage
 import com.github.jershell.kbson.models.polymorph.SealedWrapper
 import com.github.jershell.kbson.models.polymorph.StringMessage
@@ -1130,6 +1133,52 @@ class KBsonTest {
                 response = FooTimestampedMessage(1570459730)
             ), res2
         )
+    }
+
+    @Test
+    fun parseAnnotatedPolymorphism() {
+        val addressNoteDocument = BsonDocument().apply {
+            append("contentType", BsonString("ADDRESS"))
+            append("street", BsonString("street 1"))
+        }
+
+        val expectedAddressNote = AddressNote("street 1")
+        val actualAddressNote = KBson.default.parse(Note.serializer(), addressNoteDocument)
+
+        assertEquals(expectedAddressNote, actualAddressNote)
+
+        val phoneNoteDocument = BsonDocument().apply {
+            append("contentType", BsonString("PHONE"))
+            append("phoneNumber", BsonString("00123456789"))
+        }
+
+        val expectedPhoneNote = PhoneNote("00123456789")
+        val actualPhoneNote = KBson.default.parse(Note.serializer(), phoneNoteDocument)
+
+        assertEquals(expectedPhoneNote, actualPhoneNote)
+    }
+
+    @Test
+    fun encodeAnnotatedPolymorphism() {
+        val addressNote = AddressNote("street 1")
+        val expectedAddressNoteDocument = BsonDocument().apply {
+            append("contentType", BsonString("ADDRESS"))
+            append("street", BsonString("street 1"))
+        }
+
+        val actualAddressNoteDocument = KBson.default.stringify(Note.serializer(), addressNote)
+
+        assertEquals(expectedAddressNoteDocument, actualAddressNoteDocument)
+
+        val phoneNote = PhoneNote("00123456789")
+        val expectedPhoneNoteDocument = BsonDocument().apply {
+            append("contentType", BsonString("PHONE"))
+            append("phoneNumber", BsonString("00123456789"))
+        }
+
+        val actualPhoneNoteDocument = KBson.default.stringify(Note.serializer(), phoneNote)
+
+        assertEquals(expectedPhoneNoteDocument, actualPhoneNoteDocument)
     }
 
     @Test

--- a/src/test/kotlin/com/github/jershell/kbson/models/polymorph/Annotated.kt
+++ b/src/test/kotlin/com/github/jershell/kbson/models/polymorph/Annotated.kt
@@ -1,0 +1,21 @@
+package com.github.jershell.kbson.models.polymorph
+
+import com.github.jershell.kbson.BsonClassDiscriminator
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@BsonClassDiscriminator("contentType")
+sealed interface Note
+
+@Serializable
+@SerialName("ADDRESS")
+data class AddressNote(
+    val street: String,
+): Note
+
+@Serializable
+@SerialName("PHONE")
+data class PhoneNote(
+    val phoneNumber: String,
+): Note


### PR DESCRIPTION
### Current state
When serializing polymorphic classes by default an element with name `___type` is added to the BSON document as class discriminator.
The element name can be changed by changing the `Configuration.classDiscriminator` property. But this changes the element name for **every** polymorphic class. Currently, there is no way to change the name on class level.

### Use-case
When persisting a document in MongoDB the class discriminator name is relevant for querying.
Names like `___type` or `type` for all polymorphic classes are insufficient when you want to use other discriminators such as `isoCountryCode`.

### Proposed solution
This PR adds the annotation `BsonClassDiscriminator` just like `JsonClassDiscriminator` for the JSON format maintained by JetBrains. This way the class discriminator element name can be set for each class individually.

```kotlin
@Serializable
@BsonClassDiscriminator("isoCountryCode")
sealed interface ImportDocument

@Serializable
@SerialName("JP") // will result in the element "isoCountryCode": "JP" 
class JapaneseImportDocument(
    // country specific fields
) : ImportDocument
```