### PR TITLE
Look up the class discriminator value by its name in the PolymorphismDecoder

### DIFF
--- a/src/test/kotlin/com/github/jershell/kbson/KBsonTest.kt
+++ b/src/test/kotlin/com/github/jershell/kbson/KBsonTest.kt
@@ -1306,6 +1306,18 @@ class KBsonTest {
             })
         }
 
+        // class discriminator at a non-standard location
+        val doc6 = BsonDocument().apply {
+            append("payload", BsonDocument().apply {
+                append("_id", BsonObjectId(ObjectId("5d1777814e8c7b408a6ada73")))
+                append("someData", BsonString("something"))
+                append(
+                    conf.classDiscriminator,
+                    BsonString("com.github.jershell.kbson.models.polymorph.SMessage.DataWithObjectId")
+                )
+            })
+        }
+
         val polyBson = KBson(serializersModule = DefaultModule + pModule)
 
         val res1 = polyBson.parse(SealedWrapper.serializer(), doc1)
@@ -1318,6 +1330,8 @@ class KBsonTest {
 
         val res5 = polyBson.parse(SealedWrapper.serializer(), doc5)
 
+        val res6 = polyBson.parse(SealedWrapper.serializer(), doc6)
+
         assertTrue(res1.payload is SMessage.Error)
         assertTrue(res2.payload is SMessage.Loading)
         assertEquals(SealedWrapper(SMessage.Data(someData = "something")), res3)
@@ -1329,6 +1343,14 @@ class KBsonTest {
                     _id = ObjectId("5d1777814e8c7b408a6ada73")
                 )
             ), res5
+        )
+        assertEquals(
+            SealedWrapper(
+                SMessage.DataWithObjectId(
+                    someData = "something",
+                    _id = ObjectId("5d1777814e8c7b408a6ada73")
+                )
+            ), res6
         )
     }
 


### PR DESCRIPTION
### Current state
The PolymorphismDecoder expects the first field in the BSON document (or the second, if the first one is the `_id`) to contain the class discriminator. If the discriminator field is at another position in the document, deserialization fails.

Example:
Parsing the following document
```json
{
  "payload": {
    "_id": {
      "$oid": "5d1777814e8c7b408a6ada73"
    },
    "someData": "something",
    "___type": "com.github.jershell.kbson.models.polymorph.SMessage.DataWithObjectId"
  }
}
```
leads to
```
Serializer for subclass 'something' is not found in the polymorphic scope of 'SMessage'.
Check if class with serial name 'something' exists and serializer is registered in a corresponding SerializersModule.
To be registered automatically, class 'something' has to be '@Serializable', and the base class 'SMessage' has to be sealed and '@Serializable'.
```

### Proposed solution
With this pull request, `decodeElementIndex` actively looks for a field with the configured class discriminator's name. It also allows removing the `alreadyReadId` parameters introduced in https://github.com/jershell/kbson/pull/19.
This change adds a few more read calls, but I think the tradeoff is worth it for a bit more robustness.